### PR TITLE
fix: Fix regex to be able to accept multiple route slashes. Closes #26

### DIFF
--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -58,7 +58,11 @@ export class AuthService {
    * @param client - The client object to register.
    */
   registerClient(client): Observable<any> {
-    return this.http.post(this.clientUrl, {'clientInformation': client})
+    const headers = new Headers();
+
+    headers.append('authorization', PublicFunctions.getCookie('token'));
+
+    return this.http.post(this.clientUrl, {'clientInformation': client}, {headers})
             .map((data) => {
                 return data.json();
             }).catch((error) => {

--- a/src/app/auth/open-register-client/open-register-client.component.ts
+++ b/src/app/auth/open-register-client/open-register-client.component.ts
@@ -24,7 +24,7 @@ export class OpenRegisterClientComponent implements OnInit {
   passwordConfirm: string;
   isDone = true;
   hostUriRegex = /^https:\/\/(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/m;
-  redirectUrisRegex = /^\/[a-zA-Z0-9/]{1,100}$/m;
+  redirectUrisRegex = /^(\/[a-zA-Z0-9]{1,20}){1,10}$/m;
 
   AUTHORIZE_HELP = 'For use with requests from a web server. This is the path' +
                    'in your application that users are redirected to after they' +
@@ -85,7 +85,7 @@ export class OpenRegisterClientComponent implements OnInit {
     this.appName = this.registerClientFormGroup.value.appname;
     this.hostUri = this.registerClientFormGroup.value.hostUri;
 
-    this.authService.registerClient({'appname': this.appName,
+    this.authService.registerClient({'name': this.appName,
                                      'redirectUris': this.redirectUris.map(value => this.hostUri + value),
                                      'hostUri': this.hostUri}).subscribe((data) => {
       if (data) {


### PR DESCRIPTION
### Now regex is able to accept multiple `/` 
**Few Examples:**
- `/api/v1/auth/register/user` is **valid**.
- `/api/v1/auth/register/user/` is **invalid**.
- `//` is **invalid**.
- More than 10 route slashes (`/`) are also **invalid**.